### PR TITLE
feat(tango): they have been saved

### DIFF
--- a/src/App/wwwroot/data/corpses.json
+++ b/src/App/wwwroot/data/corpses.json
@@ -86,13 +86,6 @@
       "link": "https://www.theverge.com/24151047/xbox-shuts-down-arkane-austin-tango-gameworks-microsoft"
     },
     {
-      "name": "Tango Gameworks",
-      "birthDate": "2010-03-01",
-      "deathDate": "2024-05-07",
-      "description": "a Japanese game development studio that was acquired by Microsoft with the acquisition of ZeniMax Media and known for creating The Evil Within and Hi-Fi Rush",
-      "link": "https://www.theverge.com/24151047/xbox-shuts-down-arkane-austin-tango-gameworks-microsoft"
-    },
-    {
       "name": "Xamarin",
       "birthDate": "2011-05-16",
       "deathDate": "2024-05-01",


### PR DESCRIPTION
**Summary of Changes**
Remove Tango Gameworks from the graveyard.  It's coming back to life.

- https://www.windowscentral.com/gaming/xbox/former-xbox-studio-tango-gameworks-and-hi-fi-rush-has-been-acquired-by-pubgs-krafton-inc-saving-it-from-closure